### PR TITLE
Fixed build on fresh machines.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ drunnerc
 drunner-install
 build_number.h
 version.number
+permissions
 
 # Visual Studio
 *.suo


### PR DESCRIPTION
Looks like the `permissions` file is used for testing whether the
build environment is setup up right yet. Problem is it's been commited
so the `mkdir` commands etc. are never run on a fresh machine.